### PR TITLE
fix bug with regex matching when using Python 3+

### DIFF
--- a/apache_log_parser/__init__.py
+++ b/apache_log_parser/__init__.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime, tzinfo, timedelta
+import sys
 
 import user_agents
 
@@ -220,6 +221,8 @@ class Parser:
         self.names = tuple(self.names)
 
     def parse(self, log_line):
+        if (sys.version_info.major > 2):
+            log_line = log_line.decode('utf-8')
         match = self.log_line_regex.match(log_line)
         if match is None:
             raise LineDoesntMatchException(log_line=log_line, regex=self.log_line_regex.pattern)


### PR DESCRIPTION
When using Python 3+, the ff error is generated:

```
File "/home/$USER/.local/lib/python3.6/site-packages/apache_log_parser/__init__.py", line 246, in parse
match = self.log_line_regex.match(log_line)
TypeError: cannot use a string pattern on a bytes-like object 
```
Python 3+ will return the `log_line` as a bytes-like object , which will not a compatible with the method signature. 

My proposed fix detects if the version of Python is 3+ and then decodes it into utf-8 as necessary.  
Makes the code work as expected on Python 3+.